### PR TITLE
avoid ruamel.yaml.scanner.ScannerError

### DIFF
--- a/models/n2v-sem-demo/model.yaml
+++ b/models/n2v-sem-demo/model.yaml
@@ -9,7 +9,8 @@ authors:
 documentation: README.md
 test_inputs: [ test_input.tif ]
 test_outputs: [ test_output.tif ]
-covers: [ https://raw.githubusercontent.com/bioimage-io/fiji-bioimage-io/master/models/n2v-sem-demo/thumbnail.png ]
+covers:
+  - https://raw.githubusercontent.com/bioimage-io/fiji-bioimage-io/master/models/n2v-sem-demo/thumbnail.png
 tags: [ denoising, unet2d, n2v ]
 license: BSD-3-Clause
 format_version: 0.3.2


### PR DESCRIPTION
avoid ruamel.yaml.scanner.ScannerError:

while scanning a plain scalar, line 12, column 11 found unexpected ':'
this should not be a problem, but in block style (this commit) 
or with "quotation marks" the ScannerError can be avoided.